### PR TITLE
Fix url missing and allow ip fowarding

### DIFF
--- a/hikload/util.py
+++ b/hikload/util.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 import xmltodict
 import ffmpeg
 from .config import CONFIG
+import re
 
 
 class ResponseObject(object):
@@ -53,7 +54,7 @@ def downloadRTSP(response):
                            reorder_queue_size="0",
                            timeout=0, stimeout=100,
                            rtsp_flags="listen", rtsp_transport="tcp")
-    return ffmpeg.run(stream, capture_stdout=False, capture_stderr=False)
+    return ffmpeg.run(stream, capture_stdout=True, capture_stderr=True)
 
 
 def chdir(newpath):
@@ -86,6 +87,9 @@ def getList(response):
                 "rtsp://", "rtsp://" + getConfig('user') + ":" + getConfig(
                     "password") + "@", 1)
 
+            # set the url and replace the ip returned by the server by the one configured
+            # in case of ip forwarding
+            response.url = re.sub("\\d+.\\d+.\\d+.\\d+", getConfig("server"), url)
             # This gets the camera ID
             response.camera = url.split('/')[5]
             # This gets the "name" argument from the url


### PR DESCRIPTION
I guess the url was missing in the object returned, this PR fixes this problem.

Moreover, in case of server with a ip forwarding the replacement of the returned ip makes things working.

I turned on the error/output message for debugging reason but this is not mandaroty

thanks