### PR TITLE
Add concat and trim features

### DIFF
--- a/hikload/video.py
+++ b/hikload/video.py
@@ -1,0 +1,90 @@
+import ffmpeg
+import os
+import logging
+
+from datetime import datetime
+
+logger = logging.getLogger('hikload')
+
+def concat_channel_videos(channel_metadata: dict, cid, args):
+    # Create temporary text file as the FFmpeg requires it
+    with open("tmp_list.txt", "w") as fl:
+
+        audio_codec = True
+        for filename in channel_metadata["filenames"]:
+            fl.write("file '{}'\n".format(filename))
+            
+            # Find out if the file has audio stream 
+            has_audio = False
+            probe = ffmpeg.probe(filename)
+            for stream in probe["streams"]:
+                if stream["codec_type"].lower() == "audio":
+                    has_audio = True
+                    break
+            audio_codec = audio_codec and has_audio
+    
+    if args.videoname != "":
+        outname = "{}-{}.{}".format(
+            args.videoname,
+            cid,
+            args.videoformat
+        )
+    else:
+        outname = "{}-{}.{}".format(
+            channel_metadata["startTime"].replace("-", "").replace(":", "").replace("Z", "").replace("T", ""),
+            cid,
+            args.videoformat
+        )
+
+    try:
+        (
+            ffmpeg
+            .input('tmp_list.txt', f='concat', safe=0)
+            .output(outname, codec='copy')
+            .overwrite_output()
+            .run()
+        )
+    except ffmpeg._run.Error:
+        # The FFmpeg thrown error while running
+        # This could be because of unsupported audio codec (or the audio is missing)
+        # Try to cocatenate without the audio stream
+        (
+            ffmpeg
+            .input('tmp_list.txt', f='concat', safe=0)
+            .output(outname, vcodec='copy')
+            .overwrite_output()
+            .run()
+        )
+
+    # Clean up after yourself
+    os.remove("tmp_list.txt")
+    for filename in channel_metadata["filenames"]:
+        os.remove(filename)
+
+    logging.debug("Recordings of the channel {} concatenated into video {}".format(cid, outname))
+    return outname
+
+
+def cut_video(video_name, channel_metadata: dict):
+    # Cut videos to required duration
+    starttime = datetime.strptime(
+        channel_metadata["startTime"], "%Y-%m-%dT%H:%M:%SZ")
+    minstarttime = datetime.strptime(
+        channel_metadata["minStartTime"], "%Y-%m-%dT%H:%M:%SZ")
+    trim_start =  starttime - minstarttime 
+    
+    outname = video_name.replace(".", "_cut.")
+    (
+        ffmpeg
+        .input(video_name, ss=trim_start, t=channel_metadata["duration"])
+        .output(outname, codec='copy')
+        .overwrite_output()
+        .global_args('-loglevel', 'error')
+        .run()
+    )
+
+    # Clean up after yourself
+    os.remove(video_name)
+
+    logging.debug("Video {} trimed into video".format(video_name, outname))
+    return outname


### PR DESCRIPTION
Adding the concatenation and trim features described in #24 . Closes #24 

Please, test the changes on other Hikvision model. I tested with my NVR but it has some limitations.

# main changes:

1. Replace downloadQueue with downloadDict to store channel metadata
2. Save true startTime and endTime of recordings to enable triming of the concatenated video
3. Add _--concat_ option to concatenate all recordings from one channel
4. Add _--trim_ option to cut beginning and end of the concatenated video
5. Add _--videoname_ option to add custom name to videos

# Details

Below i shortly explain the approach for reviewers to understand the code faster.

## 1. downloadDict

Since I need to store metadata for each channel and the session, I use the downloadDict instead of former downloadQueue. The main cons is the added complexity in both processing and coding but it enables us to store more than just individual recordings.

## 2. Saving true startTime and endTime

Since the IS API does not return the true startTime and endTime for border recordings, I bypassed the problem by listing more recordings than required by the timespan. It slows down the discovery process as we load more recordings than necessary but the difference is smaller than 1s which I think is not important when downloading and concatenating videos take tens of minutes.

I hard-coded the additional 2 days to the search query. The approach would fail when the video is in such a low quality that one recording spans more than one day. This is a tradeoff between universality and speed. We can always list all recordings available but that takes time in tens of seconds.

## 3., 4. Concat and trim

As outlined in the issue #24 , the approach is to always create a new video when processing recordings with FFmpeg. It means temporarily storing some videos but it speeds up the process as we can copy videos and encodings. The temporary videos are deleted after the end of session.

There was a problem with video audio. See the code for details.

## 5. Videoname

The _--videoname_ option is nor directly related to the concat and trim problem. It is possible to implement the feature without it. The main question then would be how to uniquely name the concatenated video.

# Notes

- While implementing the feature, the _download.py_ grew in length. I suggest moving some functions in a new _utils.py_  file and recaftor the _download.py_ file in furute pull requests.

