### PR TITLE
Add option to time out hanging HTP connections automatically.

### DIFF
--- a/hikload/download.py
+++ b/hikload/download.py
@@ -102,7 +102,7 @@ def parse_args():
                         help='enable concatenating downloaded vides into one file (channel-wise)')
     parser.add_argument('--trim', dest="trim", action=argparse.BooleanOptionalAction,
                         help='enable triming of the concatenated video. Does work only with --concat enabled')
-    parser.add_argument('--httptimeout', dest="httptimeout",
+    parser.add_argument('--httptimeout', dest="httptimeout", type=int,
                         help='HTTP requests will time out after a given seconds of server inactivity while waiting for an answer')
     parser.add_argument('--ui', dest="ui", action=argparse.BooleanOptionalAction,
                         # If running under PyInstaller, use the UI

--- a/hikload/download.py
+++ b/hikload/download.py
@@ -102,6 +102,8 @@ def parse_args():
                         help='enable concatenating downloaded vides into one file (channel-wise)')
     parser.add_argument('--trim', dest="trim", action=argparse.BooleanOptionalAction,
                         help='enable triming of the concatenated video. Does work only with --concat enabled')
+    parser.add_argument('--httptimeout', dest="httptimeout",
+                        help='HTTP requests will time out after a given seconds of server inactivity while waiting for an answer')
     parser.add_argument('--ui', dest="ui", action=argparse.BooleanOptionalAction,
                         # If running under PyInstaller, use the UI
                         default=bool(getattr(sys, 'frozen', False)),
@@ -515,7 +517,7 @@ def run(args):
             "No password specified! You need to specify a password with --password")
 
     server = hikvisionapi.HikvisionServer(
-        args.server, args.username, args.password)
+        args.server, args.username, args.password, httptimeout=args.httptimeout)
 
     FORMAT = "[%(name)s - %(funcName)20s() ] %(message)s"
     logging.basicConfig(format=FORMAT)

--- a/hikload/hikvisionapi/_ContentMgmt.py
+++ b/hikload/hikvisionapi/_ContentMgmt.py
@@ -6,8 +6,9 @@ logger = logging.getLogger('hikload')
 
 
 class _search():
-    def __init__(self, parent):
+    def __init__(self, parent, httptimeout):
         self.parent = parent.parent
+        self.httptimeout = httptimeout
 
     def profile(self):
         """
@@ -16,15 +17,15 @@ class _search():
         request (see “/ISAPI/ContentMgmt/search”). Devices that support the ‘Full’ search profile must outline
         their parameter limits, as described in the following schema
         """
-        return hikvisionapi.getXML(self.parent, "ContentMgmt/search/profile")
+        return hikvisionapi.getXML(self.parent, "ContentMgmt/search/profile", httptimeout=self.httptimeout)
 
     def getRaw(self, data: dict):
-        return hikvisionapi.postXML(self.parent, "ContentMgmt/search", data=data)
+        return hikvisionapi.postXML(self.parent, "ContentMgmt/search", data=data, httptimeout=self.httptimeout)
 
     def get(self, data: dict):
         # TODO: This is a hack, since the server likes to return a limited number of results
         result = hikvisionapi.postXML(
-            self.parent, "ContentMgmt/search", data=data)
+            self.parent, "ContentMgmt/search", data=data, httptimeout=self.httptimeout)
         if result['CMSearchResult']['responseStatusStrg'] == "NO MATCHES":
             return result
         original = result
@@ -44,7 +45,7 @@ class _search():
                     ['timeSpan']['startTime']
                 )
                 result = hikvisionapi.postXML(
-                    self.parent, "ContentMgmt/search", data=data)
+                    self.parent, "ContentMgmt/search", data=data, httptimeout=self.httptimeout)
                 for i in result['CMSearchResult']['matchList']['searchMatchItem']:
                     original['CMSearchResult']['matchList']['searchMatchItem'].append(
                         i)
@@ -58,12 +59,12 @@ class _search():
 
     def download(self, data: dict):
         result = hikvisionapi.getXML(self.parent, "ContentMgmt/download",
-                                     data=data, rawResponse=True)
+                                     data=data, rawResponse=True, httptimeout=self.httptimeout)
         return result
 
     def get_download_capabilities(self):
         result = hikvisionapi.getXML(
-            self.parent, "ContentMgmt/download/capabilities")
+            self.parent, "ContentMgmt/download/capabilities", httptimeout=self.httptimeout)
         return result
 
     def downloadURI(self, playbackURI):
@@ -121,6 +122,6 @@ class _search():
 
 
 class _ContentMgmt():
-    def __init__(self, parent):
+    def __init__(self, parent, httptimeout=None):
         self.parent = parent
-        self.search = _search(self)
+        self.search = _search(self, httptimeout)

--- a/hikload/hikvisionapi/_Streaming.py
+++ b/hikload/hikvisionapi/_Streaming.py
@@ -3,20 +3,21 @@ import uuid
 
 
 class _Streaming():
-    def __init__(self, parent):
+    def __init__(self, parent, httptimeout):
         self.parent = parent
+        self.httptimeout = httptimeout
 
     def status(self):
         """
         It is used to get a device streaming status
         """
-        return hikvisionapi.getXML(self.parent, "Streaming/status")
+        return hikvisionapi.getXML(self.parent, "Streaming/status", httptimeout=self.httptimeout)
 
     def getChannels(self):
         """
         It is used to get the properties of streaming channels for the device
         """
-        return hikvisionapi.getXML(self.parent, "Streaming/channels")
+        return hikvisionapi.getXML(self.parent, "Streaming/channels", httptimeout=self.httptimeout)
 
     def putChannels(self, StreamingChannelList: str):
         """
@@ -24,7 +25,7 @@ class _Streaming():
         A StreamingChannelList can be obtained from getChannels()
         """
         return hikvisionapi.putXML(self.parent, "Streaming/channels",
-                                   xmldata=StreamingChannelList)
+                                   xmldata=StreamingChannelList, httptimeout=self.httptimeout)
 
     def postChannels(self, StreamingChannelList: str):
         """
@@ -32,21 +33,21 @@ class _Streaming():
         A StreamingChannel can be obtained from getChannels()
         """
         return hikvisionapi.postXML(self.parent, "Streaming/channels",
-                                    xmldata=StreamingChannelList)
+                                    xmldata=StreamingChannelList, httptimeout=self.httptimeout)
 
     def deleteChannels(self, StreamingChannelList):
         """
         It is used to add a streaming channel for the device.
         A StreamingChannel can be obtained from getChannels()
         """
-        return hikvisionapi.deleteXMLRaw(self.parent, "Streaming/channels")
+        return hikvisionapi.deleteXMLRaw(self.parent, "Streaming/channels", httptimeout=self.httptimeout)
 
     def getChannelByID(self, ChannelID):
         """
         It is used to get the properties of a particular streaming channel for the
         device
         """
-        return hikvisionapi.getXML(self.parent, "Streaming/channels/%s" % ChannelID)
+        return hikvisionapi.getXML(self.parent, "Streaming/channels/%s" % ChannelID, httptimeout=self.httptimeout)
 
     def putChannelByID(self, ChannelID, StreamingChannel):
         """
@@ -54,14 +55,14 @@ class _Streaming():
         device
         """
         return hikvisionapi.putXML(self.parent, "Streaming/channels/%s" % ChannelID,
-                                   StreamingChannel)
+                                   StreamingChannel, httptimeout=self.httptimeout)
 
     def deleteChannelByID(self, ChannelID):
         """
         It is used to get the properties of a particular streaming channel for the
         device
         """
-        return hikvisionapi.deleteXML(self.parent, "Streaming/channels/%s" % ChannelID)
+        return hikvisionapi.deleteXML(self.parent, "Streaming/channels/%s" % ChannelID, httptimeout=self.httptimeout)
 
     def getChannelRTSP(self, ChannelID):
         """
@@ -73,4 +74,4 @@ class _Streaming():
         if control['ControlProtocol']['streamingTransport'] != "RTSP":
             raise hikvisionapi.HikvisionException(
                 "Cannot get RTSP link for this ChannelID")
-        return "rtsp://%s:554/Streaming/channels/%s" % (self.parent.address(protocol=False, credentials=True), ChannelID)
+        return "rtsp://%s:554/Streaming/channels/%s" % (self.parent.address(protocol=False, credentials=True),ChannelID)

--- a/hikload/hikvisionapi/_System.py
+++ b/hikload/hikvisionapi/_System.py
@@ -2,14 +2,15 @@ import hikload.hikvisionapi as hikvisionapi
 
 
 class _System():
-    def __init__(self, parent):
+    def __init__(self, parent, httptimeout):
         self.parent = parent
+        self.httptimeout = httptimeout
 
     def getDeviceInfo(self):
         """
         Returns the device info as a dictionary
         """
-        return hikvisionapi.getXML(self.parent, "System/deviceInfo")
+        return hikvisionapi.getXML(self.parent, "System/deviceInfo", httptimeout=self.httptimeout)
 
     def activateDevice(self, password: str):
         """
@@ -22,28 +23,28 @@ class _System():
         xml['ActivateInfo']['password'] = password
         data = hikvisionapi.dict2xml(xml)
 
-        return hikvisionapi.postXML(self.parent, "System/activate", data)
+        return hikvisionapi.postXML(self.parent, "System/activate", data, httptimeout=self.httptimeout)
 
     def getCapabilities(self):
         """
         It is used to get device capability.
         """
-        return hikvisionapi.getXML(self.parent, "System/capabilities")
+        return hikvisionapi.getXML(self.parent, "System/capabilities", httptimeout=self.httptimeout)
 
     def reboot(self):
         """
         Reboot the device.
         """
-        return hikvisionapi.putXML(self.parent, "System/reboot")
+        return hikvisionapi.putXML(self.parent, "System/reboot", httptimeout=self.httptimeout)
 
     def getConfigurationData(self):
         """
         Get device’s configuration data.
         """
-        return hikvisionapi.getXML(self.parent, "System/configurationData")
+        return hikvisionapi.getXML(self.parent, "System/configurationData", httptimeout=self.httptimeout)
 
     def factoryReset(self):
         """
         Get device’s configuration data.
         """
-        return hikvisionapi.putXML(self.parent, "System/factoryReset")
+        return hikvisionapi.putXML(self.parent, "System/factoryReset", httptimeout=self.httptimeout)

--- a/hikload/hikvisionapi/classes.py
+++ b/hikload/hikvisionapi/classes.py
@@ -19,14 +19,14 @@ class HikvisionServer:
                         Should be `http`(default) or `https`
     """
 
-    def __init__(self, host, user, password, protocol="http"):
+    def __init__(self, host, user, password, protocol="http", httptimeout: int | None = None):
         self.host = host
         self.protocol = protocol
         self.user = user
         self.password = password
-        self.System = _System(self)
-        self.Streaming = _Streaming(self)
-        self.ContentMgmt = _ContentMgmt(self)
+        self.System = _System(self, httptimeout)
+        self.Streaming = _Streaming(self, httptimeout)
+        self.ContentMgmt = _ContentMgmt(self, httptimeout)
 
     def __repr__(self) -> str:
         return "%s(host=%s, protocol=%s, user=%s)" % (self.__class__.__name__, self.host, self.protocol, self.user)

--- a/hikload/ui.py
+++ b/hikload/ui.py
@@ -106,7 +106,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.move(frameGm.topLeft())
 
         server = HikvisionServer(
-            self.args.server, self.args.username, self.args.password)
+            self.args.server, self.args.username, self.args.password, httptimeout=args.httptimeout)
         self.downloadthread = downloadThread(self, server, args)
         self.downloadthread.start()
 
@@ -215,7 +215,7 @@ class Startup(QtWidgets.QDialog):
         if not self.args.mock:
             try:
                 server = HikvisionServer(self.ui.server_ip.text(
-                ), self.ui.username.text(), self.ui.password.text())
+                ), self.ui.username.text(), self.ui.password.text(), httptimeout=self.args.httptimeout)
                 server.test_connection()
                 channelList = server.Streaming.getChannels()
                 self.ui.cameras.clear()


### PR DESCRIPTION
Without this, network or device glitches can cause the script to run indefinitely while waiting for HTTP responses. This is especially painful for scheduled jobs as they will be left hanging.